### PR TITLE
Add `(require 'cl)`

### DIFF
--- a/cuda-mode.el
+++ b/cuda-mode.el
@@ -25,6 +25,7 @@
 ;;; Code:
 
 (require 'cc-mode)
+(require 'cl)
 
 ;; These are only required at compile time to get the sources for the
 ;; language constants.  (The cc-fonts require and the font-lock


### PR DESCRIPTION
I got an `Debugger entered--Lisp error: (void-function cl-macroexpand-all)` error when using the package directly. According to [this post](https://github.com/Emacs-D-Mode-Maintainers/Emacs-D-Mode/issues/23), I added a `(require 'cl)` statement, which fixes my problem. I am not sure whether it is the right fix though, but hope it is helpful.
