### PR TITLE
Add second autoload for auto-mode-alist

### DIFF
--- a/cuda-mode.el
+++ b/cuda-mode.el
@@ -315,6 +315,7 @@ Each list item should be a regexp matching a single identifier."
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.cu\\'" . cuda-mode))
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.cuh\\'" . cuda-mode))
 
 ;;;###autoload


### PR DESCRIPTION
I think this second one was forgotten, since the magic comment only works on a single block.