### PR TITLE
require compat package

### DIFF
--- a/cuda-mode.el
+++ b/cuda-mode.el
@@ -7,6 +7,8 @@
 ;; Keywords: c, languages, cuda
 ;; Version: 0.1
 
+;; Package-Requires: ((compat "29"))
+
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
@@ -25,6 +27,8 @@
 ;; Originally found on EmacsWiki @ http://www.emacswiki.org/emacs/CudaMode
 
 ;;; Code:
+
+(require 'compat)
 
 (require 'cc-mode)
 


### PR DESCRIPTION
To have `defvar-keymap` for emacs < 29.